### PR TITLE
Proposal: Localization

### DIFF
--- a/Localization/Localizable.swift
+++ b/Localization/Localizable.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Formalizes resolving localizations in feature module oriented codebase.
+/// - Note: Implement this protocol when adding new localizable file in a feature module.
+protocol Localizable {
+
+    /// Gets name of the table file containing localized strings
+    var tableName: String { get }
+
+    /// Gets localized string for provided localization key
+    var localized: String { get }
+
+    /// Set it to module bundle to be able to retrieve localization files from module's bundle.
+    var bundle: Bundle { get }
+
+}
+
+
+/// Provides default implementation for `localized` property
+extension Localizable where Self: RawRepresentable, Self.RawValue == String {
+
+    /// Gets localized string from configured `tableName`
+    var localized: String {
+        NSLocalizedString(rawValue, tableName: tableName, bundle: bundle, value: "**\(rawValue)**", comment: "")
+    }
+
+}

--- a/Localization/LocalizableKeysProtocol.swift
+++ b/Localization/LocalizableKeysProtocol.swift
@@ -1,17 +1,29 @@
+/// Formalizes accessing localization keys through `Localizable` in feature module oriented codebase.
+/// - Note: Extend `Strings` with this protocol when adding new localizable file in a feature module.
 protocol LocalizableKeysProtocol {
 
+    /// Concrete `Localizable` enumeration type used for accessing cases.
     associatedtype LocalizableKeys: Localizable
 
 }
 
+/// Provides default implementations for transforming `Localizable` case into a concrete String.
 extension LocalizableKeysProtocol {
 
+    /// Returns concrete localized String for the given localization key
+    ///
+    /// - parameter key: Localization key as enumeration case in `Localizable` enumeration
     static func localized(_ key: LocalizableKeys) -> String {
         key.localized
     }
 
-    static func localized(_ key: LocalizableKeys, arguments: [CVarArg]) -> String {
-        String(format: key.localized, arguments: arguments)
+    /// Returns concrete localized `String` for the given localization key using it as a template
+    /// into which the remaining argument values are substituted
+    ///
+    /// - parameter format: Localization key as enumeration case in `Localizable` enumeration used as a template
+    /// - parameter arguments: Values used as format substitutes
+    static func localized(format: LocalizableKeys, _ arguments: CVarArg...) -> String {
+        String(format: format.localized, arguments: arguments)
     }
 
 }

--- a/Localization/LocalizableKeysProtocol.swift
+++ b/Localization/LocalizableKeysProtocol.swift
@@ -1,0 +1,17 @@
+protocol LocalizableKeysProtocol {
+
+    associatedtype LocalizableKeys: Localizable
+
+}
+
+extension LocalizableKeysProtocol {
+
+    static func localized(_ key: LocalizableKeys) -> String {
+        key.localized
+    }
+
+    static func localized(_ key: LocalizableKeys, arguments: [CVarArg]) -> String {
+        String(format: key.localized, arguments: arguments)
+    }
+
+}

--- a/Localization/README.md
+++ b/Localization/README.md
@@ -1,0 +1,76 @@
+# Localization
+This folder will contain files needed to formalize retrieving of localized strings.
+
+<br /> 
+
+## Table of Contents
+* [Overview](#overview)
+* [Setup](#setup)
+* [Usage](#usage)
+
+<br /> 
+
+## Overview
+
+A combination of `Localizable` and `LocalizableKeysProtocol` is used to formalize localization.
+This combination provides a simple and compact way of retrieving localized strings in single and multi-module projects.
+
+[Localizable](Localizable.swift) is a protocol that links localization keys from `.strings` file with the string enumeration localization cases to be able to retrieve concrete localization strings.
+
+[LocalizableKeysProtocol](LocalizableKeysProtocol.swift) is a protocol that links `String` and `Localizable` enumeration to be able to use enumeration cases in `.localized(_)` and the `.localized(format:_:...)` functions.
+
+<br /> 
+
+## Setup
+In `LocalizableStrings.swift` only hold localization keys for that module.
+
+```swift
+enum LocalizableStrings: String {
+
+    case firstLocalization
+    case secondLocalizationFormat
+    case thirdLocalization
+    case fourthLocalizationFormat
+
+}
+```
+In `LocalizableStrings+Localizable.swift`:
+ - extend previously created enumeration with `Localizable` and set getters for the `bundle` and the `tableName`.
+
+ - extend `String` with `LocalizableKeysProtocol` to associate concrete `Localizable` type by implementing `LocalizableKeys` typealias. In other words, "register" `LocalizableStrings` enumeration.
+
+See [LocalizableKeysProtocol.swift](LocalizableKeysProtocol.swift) and [Localizable.swift](Localizable.swift) files for more details.
+
+```swift
+extension LocalizableStrings: Localizable {
+
+    var bundle: Bundle {
+        Bundle.main
+    }
+
+    var tableName: String {
+        "LocalizationTableName"
+    }
+
+}
+
+extension String: LocalizableKeysProtocol {
+
+    typealias LocalizableKeys = LocalizableStrings
+
+}
+```
+
+<br /> 
+
+## Usage
+
+After everything is set up, you should be able to access localization strings as follows:
+
+```swift
+func styleViews() {
+    firstLabel.text = .localized(.firstLocalization)
+
+    secondLabel.text = .localized(format: .secondLocalizationFormat, "A substitute string")
+}
+```


### PR DESCRIPTION
# Localization
This folder will contain files needed to formalize retrieving of localized strings.

<br /> 

## Table of Contents
* [Overview](#overview)
* [Setup](#setup)
* [Usage](#usage)

<br /> 

## Overview

A combination of `Localizable` and `LocalizableKeysProtocol` is used to formalize localization.
This combination provides a simple and compact way of retrieving localized strings in single and multi-module projects.

[Localizable](Localizable.swift) is a protocol that links localization keys from `.strings` file with the string enumeration localization cases to be able to retrieve concrete localization strings.

[LocalizableKeysProtocol](LocalizableKeysProtocol.swift) is a protocol that links `String` and `Localizable` enumeration to be able to use enumeration cases in `.localized(_)` and the `.localized(format:_:...)` functions.

<br /> 

## Setup
In `LocalizableStrings.swift` only hold localization keys for that module.

```swift
enum LocalizableStrings: String {

    case firstLocalization
    case secondLocalizationFormat
    case thirdLocalization
    case fourthLocalizationFormat

}
```

In `LocalizableStrings+Localizable.swift`:
 - extend previously created enumeration with `Localizable` and set getters for the `bundle` and the `tableName`.

 - extend `String` with `LocalizableKeysProtocol` to associate concrete `Localizable` type by implementing `LocalizableKeys` typealias. In other words, "register" `LocalizableStrings` enumeration.

See [LocalizableKeysProtocol.swift](LocalizableKeysProtocol.swift) and [Localizable.swift](Localizable.swift) files for more details.

```swift
extension LocalizableStrings: Localizable {

    var bundle: Bundle {
        Bundle.main
    }

    var tableName: String {
        "LocalizationTableName"
    }

}

extension String: LocalizableKeysProtocol {

    typealias LocalizableKeys = LocalizableStrings

}
```

<br /> 

## Usage

After everything is set up, you should be able to access localization strings as follows:

```swift
func styleViews() {
    firstLabel.text = .localized(.firstLocalization)

    secondLabel.text = .localized(format: .secondLocalizationFormat, "A substitute string")
}
```