### PR TITLE
Proposal: File length

### DIFF
--- a/SwiftLint/.swiftlint.yml
+++ b/SwiftLint/.swiftlint.yml
@@ -5,6 +5,9 @@ identifier_name:
 line_length: 
   warning: 120
   ignores_comments: true
+file_length:
+  warning: 600
+  error: 1200
 type_name:
   max_length: 50
 function_parameter_count:


### PR DESCRIPTION
Default values were: 
```
warning: 400 
error: 100
```

so the additional 200 lines buffer should be enough to cover constructing views from code. 