### PR TITLE
Custom SwiftLint rule: Newline after opening and before closing braces in type definitions

### DIFF
--- a/SwiftLint/.swiftlint.yml
+++ b/SwiftLint/.swiftlint.yml
@@ -11,3 +11,13 @@ function_parameter_count:
   warning: 9
   error: 12
 large_tuple: 4
+
+custom_rules:
+  newline_after_definition_start:
+    name: "There should be an empty line after defintion opening braces"
+    regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum) (?!(?:var|let))[ a-zA-Z:,<>\n]*\{\n *\S+)'
+    severity: warning
+  newline_before_definition_end:
+    name: "There should be an empty line before defintion closing braces"
+    regex: '^[^\n]+\n\}\n'
+    severity: warning

--- a/SwiftLint/.swiftlint.yml
+++ b/SwiftLint/.swiftlint.yml
@@ -15,7 +15,7 @@ large_tuple: 4
 custom_rules:
   newline_after_definition_start:
     name: "There should be an empty line after defintion opening braces"
-    regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum) (?!(?:var|let))[ a-zA-Z:,<>\n]*\{\n *\S+)'
+    regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n]*\{\n *\S+)'
     severity: warning
   newline_before_definition_end:
     name: "There should be an empty line before defintion closing braces"

--- a/SwiftLint/.swiftlint.yml
+++ b/SwiftLint/.swiftlint.yml
@@ -14,10 +14,10 @@ large_tuple: 4
 
 custom_rules:
   newline_after_definition_start:
-    name: "There should be an empty line after defintion opening braces"
+    name: "There should be an empty line after the definition opening braces"
     regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n]*\{\n *\S+)'
     severity: warning
   newline_before_definition_end:
-    name: "There should be an empty line before defintion closing braces"
+    name: "There should be an empty line before the definition closing braces"
     regex: '^[^\n]+\n\}\n'
     severity: warning

--- a/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/.swiftlint.yml
+++ b/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/.swiftlint.yml
@@ -1,0 +1,9 @@
+custom_rules:
+  newline_after_definition_start:
+    name: "There should be an empty line after the definition opening braces"
+    regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n]*\{\n *\S+)'
+    severity: warning
+  newline_before_definition_end:
+    name: "There should be an empty line before the definition closing braces"
+    regex: '^[^\n]+\n\}\n'
+    severity: warning

--- a/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/README.md
+++ b/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/README.md
@@ -1,0 +1,159 @@
+# Custom rule documentation
+
+## newline_after_definition_start and newline_before_definition_end
+
+These rules enforce our code style for having a newline after opening and before closing braces when defining new types.
+
+<br/>
+
+NOTE: The newline_before_definition_end will not catch nested type definitions, only the most outer closing braces. I was not able to construct a regex that will stop at the proper closing brace and also check if there is not an empty line before it.
+
+<br/>
+
+### Won't trigger warning:
+
+```swift
+class VeryLongNameThisIsForAViewController: BaseViewController<VeryLongNameThisIsForAViewState,
+                                                               VeryLongNameThisIsForAViewModel> {
+
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+
+}
+```
+```swift
+class ViewController: BaseViewController<ViewState,  ViewModel> {
+
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+
+}
+```
+```swift
+class ViewController: UIViewController {
+
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+
+}
+```
+
+```swift
+class ViewController: UIViewController {
+
+    let defaultPadding: CGFloat = 16
+    
+    struct someStruct {
+       
+        let dataString: String
+        ...
+        let dataInt: Int
+
+    }
+
+}
+```
+This one is a limitation of a regex:
+```swift
+class ViewController: UIViewController {
+
+    let defaultPadding: CGFloat = 16
+
+    struct someStruct {
+       
+        let dataString: String
+        ...
+        let dataInt: Int
+    }
+
+}
+```
+
+<br/>
+
+### Will trigger warning:
+
+```swift
+class VeryLongNameThisIsForAViewController: BaseViewController<VeryLongNameThisIsForAViewState,
+                                                               VeryLongNameThisIsForAViewModel> {
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+
+}
+```
+```swift
+class VeryLongNameThisIsForAViewController: BaseViewController<VeryLongNameThisIsForAViewState,
+                                                               VeryLongNameThisIsForAViewModel> {
+
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+}
+```
+```swift
+class VeryLongNameThisIsForAViewController: BaseViewController<VeryLongNameThisIsForAViewState,
+                                                               VeryLongNameThisIsForAViewModel> {
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+}
+```
+```swift
+class ViewController: BaseViewController<ViewState,  ViewModel> {
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+}
+```
+```swift
+class ViewController: UIViewController {
+
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+}
+```
+```swift
+class ViewController: UIViewController {
+    let defaultPadding: CGFloat = 16
+
+    ...
+
+    }
+
+}
+```
+```swift
+class ViewController: UIViewController {
+
+    let defaultPadding: CGFloat = 16
+
+    struct someStruct {
+        let dataString: String
+        ...
+        let dataInt: Int
+
+    }
+
+}
+```

--- a/SwiftLint/README.md
+++ b/SwiftLint/README.md
@@ -178,7 +178,7 @@ custom_rules:
       severity: error
     newline_after_definition_start:
       name: "There should be an empty line after defintion opening braces"
-      regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum) (?!(?:var|let))[ a-zA-Z:,<>\n]*\{\n *\S+)'
+      regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n]*\{\n *\S+)'
       severity: warning
     newline_before_definition_end:
       name: "There should be an empty line before defintion closing braces"

--- a/SwiftLint/README.md
+++ b/SwiftLint/README.md
@@ -159,8 +159,8 @@ We defined custom rules using regex for:
 * force_try - because there are some force tries which are allowed in your project
 * force_cast - because there are some force casts which are allowed in your project
 * todo - because only todo with ticket number should be allowed
-* newline_after_definition_start - because there should be an empty line after the defintion opening braces
-* newline_before_definition_end - because there should be an empty line before defintion closing braces
+* newline_after_definition_start - because there should be an empty line after the definition opening braces
+* newline_before_definition_end - because there should be an empty line before the definition closing braces
 
 ```yaml
 custom_rules:
@@ -177,11 +177,11 @@ custom_rules:
       regex: 'TODO:\s(?!.*(TICKET_PREFIX-\d)).*?'
       severity: error
     newline_after_definition_start:
-      name: "There should be an empty line after defintion opening braces"
+      name: "There should be an empty line after the definition opening braces"
       regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n]*\{\n *\S+)'
       severity: warning
     newline_before_definition_end:
-      name: "There should be an empty line before defintion closing braces"
+      name: "There should be an empty line before the definition closing braces"
       regex: '^[^\n]+\n\}\n'
       severity: warning
 ```

--- a/SwiftLint/README.md
+++ b/SwiftLint/README.md
@@ -159,6 +159,8 @@ We defined custom rules using regex for:
 * force_try - because there are some force tries which are allowed in your project
 * force_cast - because there are some force casts which are allowed in your project
 * todo - because only todo with ticket number should be allowed
+* newline_after_definition_start - because there should be an empty line after the defintion opening braces
+* newline_before_definition_end - because there should be an empty line before defintion closing braces
 
 ```yaml
 custom_rules:
@@ -174,6 +176,14 @@ custom_rules:
       name: "Todo Violation: TODOs without ticket number should be resolved."
       regex: 'TODO:\s(?!.*(TICKET_PREFIX-\d)).*?'
       severity: error
+    newline_after_definition_start:
+      name: "There should be an empty line after defintion opening braces"
+      regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum) (?!(?:var|let))[ a-zA-Z:,<>\n]*\{\n *\S+)'
+      severity: warning
+    newline_before_definition_end:
+      name: "There should be an empty line before defintion closing braces"
+      regex: '^[^\n]+\n\}\n'
+      severity: warning
 ```
 
 

--- a/SwiftLint/README.md
+++ b/SwiftLint/README.md
@@ -159,8 +159,8 @@ We defined custom rules using regex for:
 * force_try - because there are some force tries which are allowed in your project
 * force_cast - because there are some force casts which are allowed in your project
 * todo - because only todo with ticket number should be allowed
-* newline_after_definition_start - because there should be an empty line after the definition opening braces
-* newline_before_definition_end - because there should be an empty line before the definition closing braces
+* [newline_after_definition_start](CustomRules/newline_after_definition_start%20and%20newline_before_definition_end/) - because there should be an empty line after the definition opening braces
+* [newline_before_definition_end](CustomRules/newline_after_definition_start%20and%20newline_before_definition_end/) - because there should be an empty line before the definition closing braces
 
 ```yaml
 custom_rules:


### PR DESCRIPTION
Introducing a custom rule to enforce our code style for having a newline after opening and before closing braces when defining new types.

NOTE: The newline_before_definition_end will not catch nested type definitions, only the most outer closing braces. I was not able to construct a regex that will stop at the proper closing brace and also check if there is not an empty line before it.

### Won't trigger warning:

```swift
class VeryLongNameThisIsForAViewController: BaseViewController<VeryLongNameThisIsForAViewState,
                                                               VeryLongNameThisIsForAViewModel> {

    let defaultPadding: CGFloat = 16

    ...

    }

}
```
```swift
class ViewController: BaseViewController<ViewState,  ViewModel> {

    let defaultPadding: CGFloat = 16

    ...

    }

}
```
```swift
class ViewController: UIViewController {

    let defaultPadding: CGFloat = 16

    ...

    }

}
```

```swift
class ViewController: UIViewController {

    let defaultPadding: CGFloat = 16
    
    struct someStruct {
       
        let dataString: String
        ...
        let dataInt: Int

    }

}
```
This one is a limitation of a regex:
```swift
class ViewController: UIViewController {

    let defaultPadding: CGFloat = 16

    struct someStruct {
       
        let dataString: String
        ...
        let dataInt: Int
    }

}
```
### Will trigger warning:

```swift
class VeryLongNameThisIsForAViewController: BaseViewController<VeryLongNameThisIsForAViewState,
                                                               VeryLongNameThisIsForAViewModel> {
    let defaultPadding: CGFloat = 16

    ...

    }

}
```
```swift
class VeryLongNameThisIsForAViewController: BaseViewController<VeryLongNameThisIsForAViewState,
                                                               VeryLongNameThisIsForAViewModel> {

    let defaultPadding: CGFloat = 16

    ...

    }
}
```
```swift
class VeryLongNameThisIsForAViewController: BaseViewController<VeryLongNameThisIsForAViewState,
                                                               VeryLongNameThisIsForAViewModel> {
    let defaultPadding: CGFloat = 16

    ...

    }
}
```
```swift
class ViewController: BaseViewController<ViewState,  ViewModel> {
    let defaultPadding: CGFloat = 16

    ...

    }
}
```
```swift
class ViewController: UIViewController {

    let defaultPadding: CGFloat = 16

    ...

    }
}
```
```swift
class ViewController: UIViewController {
    let defaultPadding: CGFloat = 16

    ...

    }

}
```
```swift
class ViewController: UIViewController {

    let defaultPadding: CGFloat = 16

    struct someStruct {
        let dataString: String
        ...
        let dataInt: Int

    }

}
```