### PR TITLE
Update: Extended a newline_after_definition_start custom rule and added a note for global functions

### DIFF
--- a/SwiftLint/.swiftlint.yml
+++ b/SwiftLint/.swiftlint.yml
@@ -15,7 +15,7 @@ large_tuple: 4
 custom_rules:
   newline_after_definition_start:
     name: "There should be an empty line after the definition opening braces"
-    regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n]*\{\n *\S+)'
+    regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n_]*\{\n *\S+)'
     severity: warning
   newline_before_definition_end:
     name: "There should be an empty line before the definition closing braces"

--- a/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/.swiftlint.yml
+++ b/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/.swiftlint.yml
@@ -1,7 +1,7 @@
 custom_rules:
   newline_after_definition_start:
     name: "There should be an empty line after the definition opening braces"
-    regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n]*\{\n *\S+)'
+    regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n_]*\{\n *\S+)'
     severity: warning
   newline_before_definition_end:
     name: "There should be an empty line before the definition closing braces"

--- a/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/README.md
+++ b/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/README.md
@@ -8,6 +8,26 @@ These rules enforce our code style for having a newline after opening and before
 
 NOTE: The newline_before_definition_end will not catch nested type definitions, only the most outer closing braces. I was not able to construct a regex that will stop at the proper closing brace and also check if there is not an empty line before it.
 
+NOTE: If you are using global functions, make sure to disable the custom rule for the range of the global functions. Example:
+
+```swift
+// swiftlint:disable newline_before_definition_end
+public func funcOne() {
+    ...
+}
+
+public func funcTwo() {
+    ...
+}
+
+// swiftlint:enable newline_before_definition_end
+public extension View {
+
+    ...
+
+}
+```
+
 <br/>
 
 ### Won't trigger warning:

--- a/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/README.md
+++ b/SwiftLint/CustomRules/newline_after_definition_start and newline_before_definition_end/README.md
@@ -8,7 +8,7 @@ These rules enforce our code style for having a newline after opening and before
 
 NOTE: The newline_before_definition_end will not catch nested type definitions, only the most outer closing braces. I was not able to construct a regex that will stop at the proper closing brace and also check if there is not an empty line before it.
 
-NOTE: If you are using global functions, make sure to disable the custom rule for the range of the global functions. Example:
+NOTE: If you are using global functions, make sure to disable the custom `newline_before_definition_end` rule for the range of the global functions. Example:
 
 ```swift
 // swiftlint:disable newline_before_definition_end

--- a/SwiftLint/README.md
+++ b/SwiftLint/README.md
@@ -178,7 +178,7 @@ custom_rules:
       severity: error
     newline_after_definition_start:
       name: "There should be an empty line after the definition opening braces"
-      regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n]*\{\n *\S+)'
+      regex: '(^[ a-zA-Z]*(?:protocol|extension|class|struct|enum)[ a-zA-Z:,<>\n_]*\{\n *\S+)'
       severity: warning
     newline_before_definition_end:
       name: "There should be an empty line before the definition closing braces"


### PR DESCRIPTION
While implementing the new custom rules to a project I noticed that: 

1. View_Previews did not trigger newline_after_definition_start rule. I have added "_" character to the rule so now that should be covered

2. newline_after_definition_end would trigger on global functions. I added a note for disabling the range of global function definition